### PR TITLE
Look for people in SDP table if not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,12 @@ const addressesTable = new AirtablePlus({
     tableName: 'Addresses'
 })
 
+const sdpTable = new AirtablePlus({
+    apiKey: process.env.AIRTABLE_API_KEY,
+    baseID: 'apptEEFG5HTfGQE7h',
+    tableName: 'SDP Priority Activations'
+})
+
 const fetchMailMission = async id => {
     console.log('Fetching mission with id '+id)
     const mission = await mailMissionsTable.read({
@@ -129,21 +135,34 @@ app.post('/address-from-contact-info', async function(req, res) {
             console.log(`i found a person record!!! their address record id is ${addressRecordId}`)
         }
         else {
-            console.log(`i did not find person but will create one!`)
-            const addressRecord = await addressesTable.create({})
-            addressRecordId = addressRecord.id
+            let sdpRecord = (await sdpTable.read({
+                filterByFormula: `GitHub Email = '${email}`,
+                maxRecords: 1
+            }))[0]
 
-            console.log(`i made a address for the new person`)
-            personRecord = await peopleTable.create({
-                'Slack ID': slackId,
-                'Email': email,
-                'Full Name': name,
-                'Address': [addressRecordId],
-                'Address History': [addressRecordId]
-            })
-            personRecordId = personRecord.id
+            if (sdpRecord) {
+                addressRecordId = sdpRecord.fields['Address (formatted)'][0]
+                personrecordId = sdpRecord.id
 
-            console.log(`i maked person. new address record id is ${addressRecordId}`)
+                console.log(`i did not find this person in the people table but i found them in the sdp table!!!`)
+            }
+            else {
+                console.log(`i did not find person but will create one!`)
+                const addressRecord = await addressesTable.create({})
+                addressRecordId = addressRecord.id
+    
+                console.log(`i made a address for the new person`)
+                personRecord = await peopleTable.create({
+                    'Slack ID': slackId,
+                    'Email': email,
+                    'Full Name': name,
+                    'Address': [addressRecordId],
+                    'Address History': [addressRecordId]
+                })
+                personRecordId = personRecord.id
+    
+                console.log(`i maked person. new address record id is ${addressRecordId}`)
+            }
         }
 
         res.send({


### PR DESCRIPTION
Fixes issue where SDP activation mail missions didn't include an address even though they included an address when they applied for the SDP. Currently completely untested, but it should work